### PR TITLE
Feat/#51 일기장 개별 조회 구현

### DIFF
--- a/src/main/java/com/pyro/yolog/domain/inquiry/exception/InquiryAnswerNotAdminMemberException.java
+++ b/src/main/java/com/pyro/yolog/domain/inquiry/exception/InquiryAnswerNotAdminMemberException.java
@@ -5,6 +5,6 @@ import com.pyro.yolog.global.error.exception.BusinessException;
 
 public class InquiryAnswerNotAdminMemberException extends BusinessException {
     public InquiryAnswerNotAdminMemberException() {
-        super(ErrorCode.INQUIRY_NOT_ADMIN_MEMBER);
+        super(ErrorCode.INQUIRY_NOT_ADMIN_MEMBER_ERROR);
     }
 }

--- a/src/main/java/com/pyro/yolog/domain/trip/api/TripApi.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/api/TripApi.java
@@ -42,7 +42,7 @@ public interface TripApi {
             )
     })
     void updateTrip(
-            @Parameter(in = ParameterIn.QUERY, description = "일기장 ID", required = true)
+            @Parameter(in = ParameterIn.PATH, description = "일기장 ID", required = true)
             Long id,
 
             @RequestBody TripRequest request
@@ -60,7 +60,7 @@ public interface TripApi {
             )
     })
     void deleteTrip(
-            @Parameter(in = ParameterIn.QUERY, description = "일기장 ID", required = true)
+            @Parameter(in = ParameterIn.PATH, description = "일기장 ID", required = true)
             Long id
     );
 
@@ -93,7 +93,7 @@ public interface TripApi {
             }
     )
     TripResponse getTrip(
-            @Parameter(in = ParameterIn.QUERY, description = "일기장 ID", required = true)
+            @Parameter(in = ParameterIn.PATH, description = "일기장 ID", required = true)
             Long id
     );
 

--- a/src/main/java/com/pyro/yolog/domain/trip/api/TripApi.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/api/TripApi.java
@@ -2,6 +2,7 @@ package com.pyro.yolog.domain.trip.api;
 
 import com.pyro.yolog.domain.trip.dto.TripRequest;
 import com.pyro.yolog.domain.trip.dto.TripResponse;
+import com.pyro.yolog.domain.trip.entity.Trip;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -77,5 +78,24 @@ public interface TripApi {
             }
     )
     List<TripResponse> getTrips();
+
+    @Operation(
+            summary = "일기장 상세 조회",
+            description = "일기장을 상세 조회합니다.",
+            security = {@SecurityRequirement(name = "access_token")}
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "OK"
+                    )
+            }
+    )
+    TripResponse getTrip(
+            @Parameter(in = ParameterIn.QUERY, description = "일기장 ID", required = true)
+            Long id
+    );
+
 
 }

--- a/src/main/java/com/pyro/yolog/domain/trip/api/TripController.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/api/TripController.java
@@ -49,7 +49,7 @@ public class TripController implements TripApi {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{id}")
     @Override
-    public TripResponse getTrip(@Parameter Long id) {
+    public TripResponse getTrip(@PathVariable Long id) {
         return tripService.getTripDetail(id);
     }
 }

--- a/src/main/java/com/pyro/yolog/domain/trip/api/TripController.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/api/TripController.java
@@ -2,7 +2,9 @@ package com.pyro.yolog.domain.trip.api;
 
 import com.pyro.yolog.domain.trip.dto.TripRequest;
 import com.pyro.yolog.domain.trip.dto.TripResponse;
+import com.pyro.yolog.domain.trip.entity.Trip;
 import com.pyro.yolog.domain.trip.service.TripService;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -44,5 +46,10 @@ public class TripController implements TripApi {
         return tripService.getTrips();
     }
 
-
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{id}")
+    @Override
+    public TripResponse getTrip(@Parameter Long id) {
+        return tripService.getTripDetail(id);
+    }
 }

--- a/src/main/java/com/pyro/yolog/domain/trip/exception/TripNotFoundException.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/exception/TripNotFoundException.java
@@ -1,0 +1,10 @@
+package com.pyro.yolog.domain.trip.exception;
+
+import com.pyro.yolog.global.error.ErrorCode;
+import com.pyro.yolog.global.error.exception.BusinessException;
+
+public class TripNotFoundException extends BusinessException {
+    public TripNotFoundException() {
+        super(ErrorCode.TRIP_NOT_FOUND_ERROR);
+    }
+}

--- a/src/main/java/com/pyro/yolog/domain/trip/service/TripService.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/service/TripService.java
@@ -8,7 +8,7 @@ import com.pyro.yolog.domain.trip.dto.TripResponse;
 import com.pyro.yolog.domain.trip.entity.Trip;
 import com.pyro.yolog.domain.trip.mapper.TripMapper;
 import com.pyro.yolog.domain.trip.repository.TripRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.pyro.yolog.domain.trip.exception.TripNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +32,7 @@ public class TripService {
 
     @Transactional
     public void updateTrip(final Long id, final TripRequest request) {
-        final Trip trip = tripRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+        final Trip trip = tripRepository.findById(id).orElseThrow(TripNotFoundException::new);
         trip.update(request);
         diaryService.deleteOutOfDuration(trip);
     }
@@ -43,12 +43,16 @@ public class TripService {
     }
 
     public Trip getTrip(final Long id) {
-        return tripRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+        return tripRepository.findById(id).orElseThrow(TripNotFoundException::new);
     }
 
     public List<TripResponse> getTrips() {
         Member login = authService.getLoginUser();
         return tripRepository.findAllByMember(login).stream()
                 .map(TripResponse::new).collect(Collectors.toList());
+    }
+
+    public TripResponse getTripDetail(Long id) {
+        return new TripResponse(getTrip(id));
     }
 }

--- a/src/main/java/com/pyro/yolog/global/error/ErrorCode.java
+++ b/src/main/java/com/pyro/yolog/global/error/ErrorCode.java
@@ -19,9 +19,10 @@ public enum ErrorCode {
 
     // INQUIRY
     INQUIRY_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당 문의를 찾지 못했습니다."),
-    INQUIRY_NOT_ADMIN_MEMBER(HttpStatus.BAD_REQUEST, "문의하기 답변은 관리자만 가능합니다."),
+    INQUIRY_NOT_ADMIN_MEMBER_ERROR(HttpStatus.BAD_REQUEST, "문의하기 답변은 관리자만 가능합니다."),
 
     // TRIP
+    TRIP_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당 일기장을 찾지 못했습니다."),
     REQUEST_COLOR_COVER_INVALID_ERROR(HttpStatus.BAD_REQUEST, "올바른 색상 코드를 입력해야 합니다."),
 
     //DIARY


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #51 

### ⚡️ 작업동기

- 일기장 개별 조회 구현

### 🔑 주요 변경사항

- 일기장 개별 조회 API를 구현했습니다.
- 일기장 엔티티를 못 찾는 경우의 Error Handling을 추가했습니다.

### 💡 관련 이슈

close #51 