### PR TITLE
Fix/#71 회원 탈퇴 시 정상적으로 멤버 삭제가 안되는 문제 해결

### DIFF
--- a/src/main/java/com/pyro/yolog/domain/auth/controller/AuthApi.java
+++ b/src/main/java/com/pyro/yolog/domain/auth/controller/AuthApi.java
@@ -38,5 +38,5 @@ public interface AuthApi {
                     )
             }
     )
-    void withdrawMember();
+    String withdrawMember();
 }

--- a/src/main/java/com/pyro/yolog/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pyro/yolog/domain/auth/controller/AuthController.java
@@ -22,7 +22,8 @@ public class AuthController implements AuthApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/withdrawal")
     @Override
-    public void withdrawMember() {
+    public String withdrawMember() {
         authService.withdrawMember();
+        return "redirect:https://yolog.store";
     }
 }

--- a/src/main/java/com/pyro/yolog/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/pyro/yolog/domain/inquiry/entity/Inquiry.java
@@ -28,8 +28,8 @@ public class Inquiry extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "inquiry_image", cascade = CascadeType.ALL)
-    private List<Inquiry> inquiries;
+    @OneToMany(mappedBy = "inquiry", cascade = CascadeType.ALL)
+    private List<InquiryImage> inquiryImages;
 
     @Builder
     public Inquiry(String title, String content, Member member) {

--- a/src/main/java/com/pyro/yolog/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/pyro/yolog/domain/inquiry/entity/Inquiry.java
@@ -7,7 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+
+import java.util.List;
 
 @Getter
 @Entity
@@ -26,6 +27,9 @@ public class Inquiry extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "inquiry_image", cascade = CascadeType.ALL)
+    private List<Inquiry> inquiries;
 
     @Builder
     public Inquiry(String title, String content, Member member) {

--- a/src/main/java/com/pyro/yolog/domain/member/entity/Member.java
+++ b/src/main/java/com/pyro/yolog/domain/member/entity/Member.java
@@ -1,9 +1,13 @@
 package com.pyro.yolog.domain.member.entity;
 
+import com.pyro.yolog.domain.inquiry.entity.Inquiry;
 import com.pyro.yolog.domain.member.dto.request.SignUpRequest;
+import com.pyro.yolog.domain.trip.entity.Trip;
 import com.pyro.yolog.global.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,7 +19,7 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String oauthId;  //로그인한 소셜 타입의 식별자 값
+    private String oauthId;
     private String nickname;
     private String email;
     private String password;
@@ -29,6 +33,12 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Status status;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Inquiry> inquiries;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Trip> trips;
 
     public void signUp(SignUpRequest dto) {
         this.nickname = dto.getNickname();

--- a/src/main/java/com/pyro/yolog/domain/trip/entity/Trip.java
+++ b/src/main/java/com/pyro/yolog/domain/trip/entity/Trip.java
@@ -1,5 +1,7 @@
 package com.pyro.yolog.domain.trip.entity;
 
+import com.pyro.yolog.domain.diary.entity.Diary;
+import com.pyro.yolog.domain.inquiry.entity.Inquiry;
 import com.pyro.yolog.domain.member.entity.Member;
 import com.pyro.yolog.domain.trip.dto.request.TripRequest;
 import com.pyro.yolog.global.config.BaseTimeEntity;
@@ -11,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Entity
@@ -42,6 +45,9 @@ public class Trip extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL)
+    private List<Diary> diaries;
 
     @Builder
     public Trip(String name, String destination, String coverImageUrl, CoverColor coverColor, SpineColor spineColor, LocalDate startDate, LocalDate finishDate, Member member) {


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #71 

### ⚡️ 작업동기

- 회원 탈퇴 시 정상적으로 멤버 삭제가 안되는 문제 해결

### 🔑 주요 변경사항

- Member와 관련된 entity cascade로 삭제
- 회원 탈퇴 처리 이후, 첫 화면으로 Redirect

### 💡 관련 이슈

close #71 